### PR TITLE
Add project: Higgs

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -807,3 +807,6 @@ projects:
   - name: voicetypr
     github_id: moinulmoin/voicetypr
     category: "ml-frameworks"
+  - name: Higgs
+    github_id: panbanda/higgs
+    category: "apps"


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Add a project

**Description:**

Higgs (panbanda/higgs), category apps. Higgs is a Rust inference server for Apple Silicon. It runs MLX models from Hugging Face behind OpenAI- and Anthropic-compatible HTTP APIs, routes requests to remote providers (OpenAI, Anthropic, Ollama) behind the same endpoint, and ships a terminal dashboard and a desktop app with per-request tracing. MIT licensed, installed with Homebrew, first released February 2026 and actively maintained.

**Checklist:**

- [x] I have read the [CONTRIBUTING](https://github.com/best-of-lists/best-of/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have not modified the `README.md` file. Projects are only supposed to be added or updated within the `projects.yaml` file since the `README.md` file is automatically generated.